### PR TITLE
fix: docker to use built packages

### DIFF
--- a/app-config.js
+++ b/app-config.js
@@ -1,0 +1,3 @@
+window["##runtimeConfig"] = {
+    appEnvironment: "local",
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     build:
       context: .
       dockerfile: ./packages/app/Dockerfile
-    environment:
-      - VITE_APP_ENVIRONMENT=local
     ports:
       - '3010:3010'
     depends_on:
@@ -27,10 +25,6 @@ services:
       - DATABASE_NAME=block-explorer
       - BLOCKCHAIN_RPC_URL=http://host.docker.internal:3050
       - BATCHES_PROCESSING_POLLING_INTERVAL=1000
-    ports:
-      - '3001:3001'
-      - '9229:9229'
-      - '9230:9230'
     restart: unless-stopped
 
   api:
@@ -45,9 +39,6 @@ services:
       - DATABASE_URL=postgres://postgres:postgres@postgres:5432/block-explorer
     ports:
       - '3020:3020'
-      - '3005:3005'
-      - '9231:9229'
-      - '9232:9230'
     depends_on:
       - worker
     restart: unless-stopped
@@ -58,8 +49,6 @@ services:
       driver: none 
     volumes:
       - postgres:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,8 @@ services:
       dockerfile: ./packages/app/Dockerfile
     environment:
       - VITE_APP_ENVIRONMENT=local
-    command: npm run --prefix packages/app dev -- --host
     ports:
       - '3010:3010'
-    volumes:
-      - ./packages/app:/usr/src/app/packages/app
-      - /usr/src/app/packages/app/node_modules
     depends_on:
       - api
     restart: unless-stopped
@@ -21,8 +17,6 @@ services:
     build:
       context: .
       dockerfile: ./packages/worker/Dockerfile
-      target: development-stage
-    command: npm run --prefix packages/worker dev:debug
     environment:
       - PORT=3001
       - LOG_LEVEL=verbose
@@ -37,17 +31,12 @@ services:
       - '3001:3001'
       - '9229:9229'
       - '9230:9230'
-    volumes:
-      - ./packages/worker:/usr/src/app/packages/worker
-      - /usr/src/app/packages/worker/node_modules
     restart: unless-stopped
 
   api:
     build:
       context: .
       dockerfile: ./packages/api/Dockerfile
-      target: development-stage
-    command: npm run --prefix packages/api dev:debug
     environment:
       - PORT=3020
       - METRICS_PORT=3005
@@ -59,9 +48,6 @@ services:
       - '3005:3005'
       - '9231:9229'
       - '9232:9230'
-    volumes:
-      - ./packages/api:/usr/src/app/packages/api
-      - /usr/src/app/packages/api/node_modules
     depends_on:
       - worker
     restart: unless-stopped


### PR DESCRIPTION
# What :computer: 
Docker compose changes to use built versions of the packages.

# Why :hand:
For CLI we don't need to map the source code and care about hot reload that's why it's better to switch to built versions of the packages.