### PR TITLE
fix: Enhanced Error Handling and Header Specification in Network Requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,11 @@ export default class SetupModule extends Module<ModuleConfig> {
     const appConfigPath = this.getInstalledModuleFilePath("app-config.js");
     const appConfig = `window["##runtimeConfig"] = ${JSON.stringify(appConfigTemplate)};`;
 
-    fs.writeFileSync(appConfigPath, appConfig, "utf-8");
+    try {
+      fs.writeFileSync(appConfigPath, appConfig, "utf-8");
+    } catch (error) {
+      throw new Error(`Error writing to app config file: ${error}`);
+    }
 
     const commandError = await helpers.executeCommand(
       `docker cp ${appConfigPath} ${this.package.name}-app-1:${APP_RUNTIME_CONFIG_PATH}`,
@@ -128,7 +132,11 @@ export default class SetupModule extends Module<ModuleConfig> {
 
       const rpcPort = l2Network.rpcUrl.split(":").at(-1) || "3050";
       const envFileContent = `VERSION=${version}${os.EOL}RPC_PORT=${rpcPort}`;
-      fs.writeFileSync(this.getInstalledModuleFilePath(".env"), envFileContent, "utf-8");
+      try {
+        fs.writeFileSync(this.getInstalledModuleFilePath(".env"), envFileContent, "utf-8");
+      } catch (error) {
+        throw new Error(`Error writing to .env file: ${error}`);
+      }
 
       await docker.compose.create(this.installedComposeFile);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,9 @@ export default class SetupModule extends Module<ModuleConfig> {
     try {
       const response = await $fetch(l2Network.rpcUrl, {
         method: "POST",
+        headers: {
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify({
           jsonrpc: "2.0",
           method: "eth_blockNumber",


### PR DESCRIPTION
# What :computer: 
* Added try-catch block around `.env` file writing for improved error handling.
* Enclosed `fs.writeFileSync` for `appConfig` in try-catch for better error management.
* Implemented explicit headers in `$fetch` requests for correct content-type specification.

# Why :hand:
* The try-catch around `.env` file writing is to ensure that any filesystem-related errors are properly caught and reported, increasing the robustness of our setup process.
* Enclosing `fs.writeFileSync` for `appConfig` within a try-catch block provides better error management, ensuring that any issues during file writing are handled gracefully.
* Explicit headers in `$fetch` requests guarantee that the server correctly interprets the request payload as JSON, following best practices and ensuring greater compatibility across different environments.

# Notes :memo:
*These changes have been thoroughly tested in a local development environment to ensure that they do not introduce any regressions in the existing functionality.*