### PR TITLE
fix: temporary set max supported be version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import ora from "ora";
 import os from "os";
 import path from "path";
 import { Module, files, git, docker, helpers, ModuleCategory, Logger } from "zksync-cli/lib";
+import { compareSemanticVersions } from "./utils.js";
 
 import type { ConfigHandler, NodeInfo } from "zksync-cli/lib";
 
@@ -14,6 +15,7 @@ const endpoints = {
   app: "http://localhost:3010",
   api: "http://localhost:3020",
 };
+const MAX_BE_VERSION = "v2.42.1";
 
 type ModuleConfig = {
   version?: string;
@@ -168,6 +170,9 @@ export default class SetupModule extends Module<ModuleConfig> {
   async getLatestVersion(): Promise<string> {
     if (!latestVersion) {
       latestVersion = await git.getLatestReleaseVersion(REPO_URL);
+    }
+    if (compareSemanticVersions(latestVersion, MAX_BE_VERSION) > 0) {
+      latestVersion = MAX_BE_VERSION;
     }
     return latestVersion;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,20 @@
+export function compareSemanticVersions(version1: string, version2: string): number {
+    const parseVersion = (version: string) => version.split('.').map(Number);
+
+    const v1 = parseVersion(version1);
+    const v2 = parseVersion(version2);
+
+    for (let i = 0; i < Math.max(v1.length, v2.length); i++) {
+        const num1 = v1[i] || 0;
+        const num2 = v2[i] || 0;
+
+        if (num1 > num2) {
+            return 1;
+        }
+        if (num1 < num2) {
+            return -1;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
# What :computer: 
Define max supported BE release version.

# Why :hand:
There will be a couple of major BE releases that we want to carefully test before exposing it to CLI. Once it's done this change will be reverted and new versions will be available again.