### PR TITLE
fix: app config for Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-version: "3.2"
-name: "zkcli-block-explorer"
-
 services:
   app:
     platform: linux/amd64

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ export default class SetupModule extends Module<ModuleConfig> {
     fs.writeFileSync(appConfigPath, appConfig, "utf-8");
 
     const commandError = await helpers.executeCommand(
-      `docker cp ${appConfigPath} ${this.package.name}-app-1:${APP_RUNTIME_CONFIG_PATH}`,
+      `docker compose cp ${appConfigPath} app:${APP_RUNTIME_CONFIG_PATH}`,
       { silent: true, cwd: this.dataDirPath }
     );
 
@@ -175,7 +175,7 @@ export default class SetupModule extends Module<ModuleConfig> {
   async cleanupIndexedData() {
     await Promise.all(
       ["worker", "api", "postgres"].map((serviceName) =>
-        helpers.executeCommand(`docker-compose rm -fsv ${serviceName}`, { silent: true, cwd: this.dataDirPath })
+        helpers.executeCommand(`docker compose rm -fsv ${serviceName}`, { silent: true, cwd: this.dataDirPath })
       )
     );
 


### PR DESCRIPTION
# What :computer: 
Fix _Wrong container name_ error on Linux.

# Why :hand:
Because of this bug the whole BE module is not working.

# Evidence :camera:
All module containers are running:
<img width="867" alt="image" src="https://github.com/matter-labs/zkcli-block-explorer/assets/6553665/b2ae0168-d425-4a1c-9198-50394329596c">