### PR TITLE
fix: add base token config for explorer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ const appConfigTemplate = {
         newProverUrl: "https://storage.googleapis.com/zksync-era-testnet-proofs/proofs_fri",
         published: true,
         rpcUrl: "http://localhost:3050",
+        baseTokenAddress: "0x000000000000000000000000000000000000800A",
       },
     ],
   },


### PR DESCRIPTION
# What :computer: 
Add base token config for explorer.

# Why :hand:
Base token support was recently added to the explorer, so we need a proper config here as well.